### PR TITLE
feat: 토큰 만료 체크 기능 구현

### DIFF
--- a/Targets/DesignKit/Sources/Views/PhoChakAlertViewController.swift
+++ b/Targets/DesignKit/Sources/Views/PhoChakAlertViewController.swift
@@ -33,6 +33,7 @@ public final class PhoChakAlertViewController: UIViewController {
     case .signOut: return "로그아웃"
     case .cacheDeletion: return "캐시삭제"
     case .networkError: return "네트워크 불안정"
+    case .tokenExpired: return "세션이 만료되었습니다"
     }
   }
 
@@ -43,6 +44,7 @@ public final class PhoChakAlertViewController: UIViewController {
     case .signOut: return "소셜계정을 다시 연결하면 정보가 복구됩니다"
     case .cacheDeletion: return "영상 캐시 데이터를 삭제합니다"
     case .networkError: return "인터넷 연결을 확인해주세요"
+    case .tokenExpired: return "다시 로그인 후 시도해 주세요"
     }
   }
 
@@ -56,6 +58,7 @@ public final class PhoChakAlertViewController: UIViewController {
     case signOut
     case cacheDeletion
     case networkError
+    case tokenExpired
   }
 
   // MARK: Initializer
@@ -154,7 +157,7 @@ private extension PhoChakAlertViewController {
 
   func setupButtons() {
     switch alertType {
-    case .networkError:
+    case .networkError, .tokenExpired:
       acceptButton.snp.makeConstraints {
         $0.leading.trailing.bottom.equalToSuperview()
         $0.height.equalTo(view.frame.height * 0.066)

--- a/Targets/Service/Sources/APIs/TokenUpdateAPI.swift
+++ b/Targets/Service/Sources/APIs/TokenUpdateAPI.swift
@@ -1,0 +1,65 @@
+//
+//  TokenUpdateAPI.swift
+//  Service
+//
+//  Created by 한상진 on 2023/02/25.
+//  Copyright © 2023 PhoChak. All rights reserved.
+//
+
+import Core
+import Domain
+import Foundation
+
+import Moya
+
+enum TokenUpdateAPI {
+  case tryUpdate
+}
+
+// MARK: - TargetType
+extension TokenUpdateAPI: TargetType {
+  var baseURL: URL {
+    URL(string: AppProperties.baseURL)!
+  }
+
+  var path: String {
+    return "/v1/user/reissue-token"
+  }
+
+  var method: Moya.Method {
+    return .post
+  }
+
+  public var sampleData: Data {
+    return .init()
+  }
+
+  public var headers: [String : String]? {
+    return [:]
+  }
+
+  public var task: Task {
+    let requestParam: [String: Any] = parameters ?? [:]
+    let encoding: ParameterEncoding
+
+    switch self.method {
+    case .post, .patch, .put, .delete:
+      encoding = JSONEncoding.default
+
+    default:
+      encoding = URLEncoding.default
+    }
+
+    return .requestParameters(parameters: requestParam, encoding: encoding)
+  }
+
+  private var parameters: [String: Any]? {
+    switch self {
+    case .tryUpdate:
+      return [
+        "accessToken": AppProperties.accessToken,
+        "refreshToken": AppProperties.refreshToken
+      ]
+    }
+  }
+}

--- a/Targets/Service/Sources/Extension/Reactive+.swift
+++ b/Targets/Service/Sources/Extension/Reactive+.swift
@@ -1,0 +1,102 @@
+//
+//  Reactive+.swift
+//  Service
+//
+//  Created by 한상진 on 2023/02/25.
+//  Copyright © 2023 PhoChak. All rights reserved.
+//
+
+import Core
+import Domain
+import UIKit
+
+import Moya
+import RxMoya
+import RxSwift
+
+public extension Reactive where Base: MoyaProviderType {
+
+  // MARK: Methods
+  func request(_ target: Base.Target) -> Single<Response> {
+    let requestSingle = Single.create { [weak base] single in
+      let cancellableToken = base?.request(target, callbackQueue: nil, progress: nil) { result in
+        switch result {
+        case let .success(response):
+          single(.success(response))
+        case let .failure(error):
+          single(.failure(error))
+        }
+      }
+
+      return Disposables.create {
+        cancellableToken?.cancel()
+      }
+    }
+
+    return requestSingle
+      .map(TokenErrorResponse.self)
+      .catchAndReturn(.init(
+        status: .init(code: PhoChakNetworkResult.P000.rawValue, message: ""),
+        data: nil
+      ))
+      .flatMap { tokenErrorResponse in
+        guard !isValidationToken(tokenErrorResponse) else { return requestSingle }
+
+        return requestUpdateToken()
+          .filter { response in
+            do {
+              if !isValidationToken(try response.map(TokenErrorResponse.self)) {
+                TokenManager.deleteAll()
+                NotificationCenter.default.post(name: Notification.Name("reSignIn"), object: nil)
+                return false
+              }
+            } catch {
+              updateToken(try response.map(SignInResponse.self).makeUserToken())
+              return true
+            }
+
+            return false
+          }
+          .asObservable()
+          .asSingle()
+          .flatMap { _ in
+            request(target)
+          }
+      }
+  }
+
+  private func requestUpdateToken() -> Single<Response> {
+    let provider: MoyaProvider<TokenUpdateAPI> = .init(plugins: [PCNetworkLoggerPlugin()])
+
+    return .create { single in
+      let cancellableToken = provider.request(.tryUpdate) { result in
+        switch result {
+        case let .success(response):
+          single(.success(response))
+        case let .failure(error):
+          single(.failure(error))
+        }
+      }
+
+      return Disposables.create {
+        cancellableToken.cancel()
+      }
+    }
+  }
+
+  private func updateToken(_ userToken: UserToken) {
+    guard let accessTokenData = userToken.accessToken.data(using: .utf8),
+          let refreshTokenData = userToken.refreshToken.data(using: .utf8)
+    else { return }
+
+    TokenManager.save(tokenType: .accessToken, data: accessTokenData)
+    TokenManager.save(tokenType: .refreshToken, data: refreshTokenData)
+  }
+
+  private func isValidationToken(_ response: TokenErrorResponse) -> Bool {
+    guard response.status.code == PhoChakNetworkResult.P203.rawValue
+    else { return true }
+
+    return false
+  }
+}

--- a/Targets/Service/Sources/PhoChakNetworkResult.swift
+++ b/Targets/Service/Sources/PhoChakNetworkResult.swift
@@ -1,5 +1,5 @@
 //
-//  PhoChakNetworkError.swift
+//  PhoChakNetworkResult.swift
 //  Service
 //
 //  Created by 한상진 on 2023/02/10.
@@ -8,23 +8,23 @@
 
 import Foundation
 
-public enum PhoChakNetworkError: Error {
-  case P000
-  case P100
-  case P200
-  case P201
-  case P202
-  case P203
-  case P204
-  case P205
-  case P300
-  case P400
-  case P410
-  case P411
-  case P412
-  case P413
-  case P414
-  case P450
+public enum PhoChakNetworkResult: String, Error {
+  case P000 = "P000"
+  case P100 = "P100"
+  case P200 = "P200"
+  case P201 = "P201"
+  case P202 = "P202"
+  case P203 = "P203"
+  case P204 = "P204"
+  case P205 = "P205"
+  case P300 = "P300"
+  case P400 = "P400"
+  case P410 = "P410"
+  case P411 = "P411"
+  case P412 = "P412"
+  case P413 = "P413"
+  case P414 = "P414"
+  case P450 = "P450"
 
   public var description: String {
     switch self {

--- a/Targets/Service/Sources/Response/FetchPresignedURLResponse.swift
+++ b/Targets/Service/Sources/Response/FetchPresignedURLResponse.swift
@@ -12,7 +12,7 @@ public struct FetchPresignedURLResponse: Decodable {
 
   // MARK: Properties
   let status: ResponseStatus
-  let uploadData: UploadData
+  let uploadData: UploadData?
 
   enum CodingKeys: String, CodingKey {
     case status

--- a/Targets/Service/Sources/Response/TokenErrorResponse.swift
+++ b/Targets/Service/Sources/Response/TokenErrorResponse.swift
@@ -1,0 +1,14 @@
+//
+//  TokenErrorResponse.swift
+//  Service
+//
+//  Created by 한상진 on 2023/02/25.
+//  Copyright © 2023 PhoChak. All rights reserved.
+//
+
+public struct TokenErrorResponse: Decodable {
+
+  // MARK: Properties
+  let status: ResponseStatus
+  let data: String?
+}

--- a/Targets/Service/Sources/Services/UploadVideoPostService.swift
+++ b/Targets/Service/Sources/Services/UploadVideoPostService.swift
@@ -39,14 +39,15 @@ public final class UploadVideoPostService: UploadVideoPostServiceType {
     fetchPresignedURL(fileType: videoFile.fileType)
       .flatMap { [weak self] response -> Single<String> in
         guard let self = self,
-              let presignedURL: URL = .init(string: response.uploadData.uploadURL),
+              let uploadData = response.uploadData,
+              let presignedURL: URL = .init(string: uploadData.uploadURL),
               let videoFileURL: URL = .init(
                 string: self.fileManager.fetchVideoURLString(name: videoFile.fileName)
               )
         else { return .error(UploadVideoPostResult.error) }
 
         return self.uploadToS3(to: presignedURL, with: videoFileURL)
-          .map { _ in response.uploadData.uploadKey }
+          .map { _ in uploadData.uploadKey }
       }
       .flatMap { [weak self] uploadKey in
         self?.uploadPost(category: category, uploadKey: uploadKey, hashTags: hashTags) ?? .just(())


### PR DESCRIPTION
❗️ 이슈 번호
Closes #23

### 📝 작업 유형

- [x] 신규 기능 추가

### 📙 작업 내역

- AlertViewController에 토큰 만료 case 추가
- AppCoordinator에 NotificationCenter Observer 추가
- 서버 네트워킹에 사용할 request 메서드 구현

<br>
<br>

### 💡 참고사항

request 메서드 호출시
- 토큰이 정상적이라면 API 정상 요청
- AccessToken이 만료되었다면 재발급 API 요청을 통해 토큰 갱신 후 request 메서드 재호출
  - RefreshToken까지 만료되어 재발급 불가하면 세션 만료 팝업창 통해 로그인 화면으로 이동