### PR TITLE
fix: 홈과 상세에서의 좋아요 동기화 이슈

### DIFF
--- a/Targets/DesignKit/Sources/Views/VIdeoPlayerView.swift
+++ b/Targets/DesignKit/Sources/Views/VIdeoPlayerView.swift
@@ -33,6 +33,7 @@ public final class VideoPlayerView: UIView {
 
   private let thumbnailImageView: UIImageView = .init()
   private let disposeBag: DisposeBag = .init()
+  private(set) var currentVideoPost: VideoPost?
 
   // MARK: Override
   public override class var layerClass: AnyClass {
@@ -67,6 +68,11 @@ public final class VideoPlayerView: UIView {
 
   // MARK: Methods
   public func configure(videoPost: VideoPost) {
+    guard currentVideoPost?.id != videoPost.id else {
+      return
+    }
+
+    self.currentVideoPost = videoPost
     thumbnailImageView.setImage(with: videoPost.shorts.thumbnailURL)
 
     self.player = .init(url: videoPost.shorts.shortsURL).then {

--- a/Targets/Domain/Sources/Entities/VideoPost.swift
+++ b/Targets/Domain/Sources/Entities/VideoPost.swift
@@ -30,7 +30,7 @@ public struct VideoPost: Equatable, Decodable {
   }
 
   public static func == (lhs: VideoPost, rhs: VideoPost) -> Bool {
-    lhs.id == rhs.id
+    lhs.id == rhs.id && lhs.isLiked == rhs.isLiked
   }
 
   // MARK: Initializer

--- a/Targets/Domain/Sources/Interfaces/VideoPostServiceType.swift
+++ b/Targets/Domain/Sources/Interfaces/VideoPostServiceType.swift
@@ -13,7 +13,16 @@ public protocol VideoPostServiceType {
   // MARK: Methods
   func fetchVideoPosts(request: FetchVideoPostRequest) -> Single<(posts: [VideoPost], isLastPage: Bool)>
   func exclameVideoPost(postID: Int) -> Single<Void>
-  func likeVideoPost(postID: Int) -> Single<Void>
-  func unlikeVideoPost(postID: Int) -> Single<Void>
   func deleteVideoPost(postID: Int) -> Single<Void>
+
+
+  /// 포스트 좋아요를 요청합니다.
+  /// - Parameter postID
+  /// - Returns: 성공의 경우 true, 실패의 경우 false를 반환합니다.
+  func likeVideoPost(postID: Int) -> Single<Bool>
+
+  /// 포스트 좋아요를 해제합니다.
+  /// - Parameter postID
+  /// - Returns: 성공의 경우 true, 실패의 경우 false를 반환합니다.
+  func unlikeVideoPost(postID: Int) -> Single<Bool>
 }

--- a/Targets/Domain/Sources/UseCases/LikeVideoPostUseCase.swift
+++ b/Targets/Domain/Sources/UseCases/LikeVideoPostUseCase.swift
@@ -11,8 +11,8 @@ import RxSwift
 public protocol LikeVideoPostUseCaseType {
 
   // MARK: Methods
-  func likeVideoPost(postID: Int) -> Observable<Void>
-  func unLikeVideoPost(postID: Int) -> Observable<Void>
+  func likeVideoPost(postID: Int) -> Observable<Bool>
+  func unLikeVideoPost(postID: Int) -> Observable<Bool>
 }
 
 final class LikeVideoPostUseCase: LikeVideoPostUseCaseType {
@@ -26,12 +26,12 @@ final class LikeVideoPostUseCase: LikeVideoPostUseCaseType {
   }
 
   // MARK: Methods
-  func likeVideoPost(postID: Int) -> Observable<Void> {
+  func likeVideoPost(postID: Int) -> Observable<Bool> {
     service.likeVideoPost(postID: postID)
       .asObservable()
   }
 
-  func unLikeVideoPost(postID: Int) -> Observable<Void> {
+  func unLikeVideoPost(postID: Int) -> Observable<Bool> {
     service.unlikeVideoPost(postID: postID)
       .asObservable()
   }

--- a/Targets/Domain/Sources/UseCases/VideoPostUseCase.swift
+++ b/Targets/Domain/Sources/UseCases/VideoPostUseCase.swift
@@ -29,12 +29,12 @@ final class VideoPostUseCase: VideoPostUseCaseType {
       .catchAndReturn(([], true))
   }
 
-  func likeVideoPost(postID: Int) -> Observable<Void> {
+  func likeVideoPost(postID: Int) -> Observable<Bool> {
     service.likeVideoPost(postID: postID)
       .asObservable()
   }
 
-  func unLikeVideoPost(postID: Int) -> Observable<Void> {
+  func unLikeVideoPost(postID: Int) -> Observable<Bool> {
     service.unlikeVideoPost(postID: postID)
       .asObservable()
   }

--- a/Targets/Feature/Sources/Home/View/VideoPostCell.swift
+++ b/Targets/Feature/Sources/Home/View/VideoPostCell.swift
@@ -113,6 +113,7 @@ final class VideoPostCell: BaseCollectionViewCell {
     likeButton.setImage(videoPost.isLiked ? .createImage(.heartOn) : .createImage(.heartOff), for: .normal)
 
     exclameButton.rx.tap
+      .subscribe(on: MainScheduler.instance)
       .subscribe(with: self, onNext: { owner, _ in
         owner.delegate?.didTapExclameButton(postID: videoPost.id)
       })
@@ -121,10 +122,7 @@ final class VideoPostCell: BaseCollectionViewCell {
     likeButton.rx.tap
       .subscribe(on: MainScheduler.instance)
       .subscribe(with: self, onNext: { owner, _ in
-        let isLiked = owner.videoPost!.isLiked
         owner.delegate?.didTapLikeButton(postID: videoPost.id)
-        owner.videoPost?.isLiked = !isLiked
-        owner.likeButton.setImage(!isLiked ? .createImage(.heartOn) : .createImage(.heartOff), for: .normal)
       })
       .disposed(by: disposeBag)
   }

--- a/Targets/Service/Sources/Response/ResponseStatus.swift
+++ b/Targets/Service/Sources/Response/ResponseStatus.swift
@@ -17,3 +17,27 @@ public struct ResponseStatus: Decodable {
     case message = "resMessage"
   }
 }
+
+extension ResponseStatus {
+  var isSuccess: Bool {
+    code == PhoChakNetworkResult.P000.rawValue
+  }
+}
+
+public struct BaseResponse: Decodable {
+
+  // MARK: Properties
+  let status: ResponseStatus
+  let data: String?
+
+  enum CodingKeys: String, CodingKey {
+    case status
+    case data
+  }
+}
+
+extension BaseResponse {
+  var isSuccess: Bool {
+    status.code == PhoChakNetworkResult.P000.rawValue
+  }
+}

--- a/Targets/Service/Sources/Services/VideoPostService.swift
+++ b/Targets/Service/Sources/Services/VideoPostService.swift
@@ -34,14 +34,16 @@ final class VideoPostService: VideoPostServiceType {
       .map { _ in }
   }
 
-  func likeVideoPost(postID: Int) -> Single<Void> {
+  func likeVideoPost(postID: Int) -> Single<Bool> {
     provider.rx.request(.likeVideoPost(postID: postID))
-      .map { _ in }
+      .map(BaseResponse.self)
+      .map { $0.isSuccess }
   }
 
-  func unlikeVideoPost(postID: Int) -> Single<Void> {
+  func unlikeVideoPost(postID: Int) -> Single<Bool> {
     provider.rx.request(.unlikeVideoPost(postID: postID))
-      .map { _ in }
+      .map(BaseResponse.self)
+      .map { $0.isSuccess }
   }
 
   func deleteVideoPost(postID: Int) -> Single<Void> {


### PR DESCRIPTION
❗️ #40 
Closes #40 홈과 상세에서의 좋아요 동기화 이슈

### 📝 작업 유형

- [x] 버그 수정

### 📙 작업 내역

- UI에서 직접적인 모델에 대한 접근을 제한하고 Reactor를 통해서만 변경하도록 수정
- VideoPlayerView에서 기존의 Video값을 가지도록 하며 configure를 통해 들어온 파라미터 Post와의 ID값 비교를 통해 모델에 대한 변경이 일어났을때만 수행하도록 변경

<br>
<br>
