### PR TITLE
fix: #49 - 상세화면에서 홈으로 pop시 AffineTransform이 의도대로 동작하지 않는 현상

### DIFF
--- a/Targets/Feature/Sources/Home/View/HomeViewController.swift
+++ b/Targets/Feature/Sources/Home/View/HomeViewController.swift
@@ -265,11 +265,5 @@ extension HomeViewController: PostRollingDelegate {
 
     collectionView.scrollRectToVisible(rect.frame, animated: false)
     collectionView.layoutIfNeeded()
-
-    if let currentCell = collectionView.cellForItem(at: .init(item: index, section: 0)) {
-      DispatchQueue.main.async { [weak currentCell] in
-        currentCell?.transform = .init(scaleX: 1.1, y: 1.1).translatedBy(x: 0, y: -20)
-      }
-    }
   }
 }


### PR DESCRIPTION


❗️ 이슈 번호
Closes #49 

### 📝 작업 유형

- [x] 버그 수정

### 📙 작업 내역

- 상세에서 홈으로의 delegate call시 적용하던 AffineTransform 제거.
- AffineTransform은 Cell을 configure 하는 시점에만 반영하도록 변경.

<br>
<br>
