### PR TITLE
refactor: #46 - Alert 사용성 개선

### DIFF
--- a/Targets/Core/Sources/Extensions/Notification+.swift
+++ b/Targets/Core/Sources/Extensions/Notification+.swift
@@ -10,4 +10,6 @@ import Foundation
 
 public extension Notification.Name {
   static let muteAllPlayers = Notification.Name("muteAllPlayers")
+  static let reSignIn = Notification.Name("reSignIn")
+  static let logout = Notification.Name("logout")
 }

--- a/Targets/DesignKit/Sources/Extensions/Alertable+.swift
+++ b/Targets/DesignKit/Sources/Extensions/Alertable+.swift
@@ -1,0 +1,68 @@
+//
+//  Alertable+.swift
+//  DesignKit
+//
+//  Created by 여정수 on 2023/04/17.
+//  Copyright © 2023 PhoChak. All rights reserved.
+//
+
+import UIKit
+
+public protocol Alertable {}
+
+public enum AlertType {
+  case profileSetting
+  case signOut
+  case logout
+  case clearCache
+  case networkError
+  case tokenExpired
+  case nicknameDuplicated
+  case exclamePost
+
+  var title: String {
+    switch self {
+    case .profileSetting: return "프로필 설정"
+    case .signOut: return "회원탈퇴"
+    case .logout: return "로그아웃"
+    case .clearCache: return "캐시삭제"
+    case .networkError: return "네트워크 불안정"
+    case .tokenExpired: return "세션이 만료되었습니다"
+    case .nicknameDuplicated: return "닉네임이 중복되었습니다"
+    case .exclamePost: return "포스팅 신고"
+    }
+  }
+
+  var message: String {
+    switch self {
+    case .profileSetting: return "닉네임을 변경하고 포착을 즐겨보세요"
+    case .signOut: return "아이디와 포스팅은 복구할 수 없습니다"
+    case .logout: return "소셜계정을 다시 연결하면 정보가 복구됩니다"
+    case .clearCache: return "영상 캐시 데이터를 삭제합니다"
+    case .networkError: return "인터넷 연결을 확인해주세요"
+    case .tokenExpired: return "다시 로그인 후 시도해 주세요"
+    case .nicknameDuplicated: return "수정 후 다시 시도해 주세요"
+    case .exclamePost: return "신고가 누적된 영상은 볼 수 없게 됩니다"
+    }
+  }
+}
+
+public extension Alertable where Self: UIViewController {
+  func presentAlert(
+    type: AlertType,
+    okAction: @escaping (() -> Void?),
+    cancelAction: (() -> Void)? = nil
+  ) {
+    let alertController: UIAlertController = .init(title: type.title, message: type.message, preferredStyle: .alert)
+    alertController.modalPresentationStyle = .overCurrentContext
+    alertController.modalTransitionStyle = .crossDissolve
+    alertController.view.backgroundColor = .createColor(.monoGray, .w950, alpha: 0.3)
+    alertController.addAction(.init(title: "확인", style: .default, handler: { _ in okAction() }))
+
+    if let cancelAction {
+      alertController.addAction(.init(title: "취소", style: .cancel, handler: { _ in cancelAction() }))
+    }
+
+    present(alertController, animated: true)
+  }
+}

--- a/Targets/DesignKit/Sources/Extensions/Alertable+.swift
+++ b/Targets/DesignKit/Sources/Extensions/Alertable+.swift
@@ -57,6 +57,7 @@ public extension Alertable where Self: UIViewController {
     alertController.modalPresentationStyle = .overCurrentContext
     alertController.modalTransitionStyle = .crossDissolve
     alertController.view.backgroundColor = .createColor(.monoGray, .w950, alpha: 0.3)
+    alertController.view.cornerRadius(radius: 16)
     alertController.addAction(.init(title: "확인", style: .default, handler: { _ in okAction() }))
 
     if let cancelAction {

--- a/Targets/DesignKit/Sources/StackViews/SettingButtons.swift
+++ b/Targets/DesignKit/Sources/StackViews/SettingButtons.swift
@@ -12,12 +12,12 @@ import RxSwift
 import SnapKit
 import Then
 
-public protocol WithdrawalButtonDelegate: AnyObject {
-  func tapWithdrawalButton()
-}
-
 public protocol SignOutButtonDelegate: AnyObject {
   func tapSignOutButton()
+}
+
+public protocol LogoutButtonDelegate: AnyObject {
+  func tapLogoutButton()
 }
 
 public protocol ClearCacheButtonDelegate: AnyObject {
@@ -28,15 +28,15 @@ public final class SettingButtons: UIStackView {
 
   // MARK: Properties
   private let disposeBag: DisposeBag = .init()
-  private let withdrawalButton: UIButton = .init()
   private let signOutButton: UIButton = .init()
+  private let logoutButton: UIButton = .init()
   private let clearCacheButton: UIButton = .init()
   private var allButtons: [UIButton] {
-    return [withdrawalButton, signOutButton, clearCacheButton]
+    return [signOutButton, logoutButton, clearCacheButton]
   }
 
-  public weak var withdrawlButtonDelegate: WithdrawalButtonDelegate?
   public weak var signOutButtonDelegate: SignOutButtonDelegate?
+  public weak var logoutButtonDelegate: LogoutButtonDelegate?
   public weak var clearCacheButtonDelegate: ClearCacheButtonDelegate?
 
   // MARK: Initializer
@@ -69,11 +69,11 @@ private extension SettingButtons {
     axis = .vertical
     backgroundColor = .createColor(.monoGray, .w800)
 
-    withdrawalButton.do {
+    signOutButton.do {
       $0.setTitle("회원탈퇴", for: .normal)
     }
 
-    signOutButton.do {
+    logoutButton.do {
       $0.setTitle("로그아웃", for: .normal)
     }
 
@@ -131,17 +131,17 @@ private extension SettingButtons {
   }
 
   func setupBind() {
-    withdrawalButton.rx.tap
-      .asSignal()
-      .emit(with: self, onNext: { owner, _ in
-        owner.withdrawlButtonDelegate?.tapWithdrawalButton()
-      })
-      .disposed(by: disposeBag)
-
     signOutButton.rx.tap
       .asSignal()
       .emit(with: self, onNext: { owner, _ in
         owner.signOutButtonDelegate?.tapSignOutButton()
+      })
+      .disposed(by: disposeBag)
+
+    logoutButton.rx.tap
+      .asSignal()
+      .emit(with: self, onNext: { owner, _ in
+        owner.logoutButtonDelegate?.tapLogoutButton()
       })
       .disposed(by: disposeBag)
 

--- a/Targets/Domain/Sources/Interfaces/SettingServiceType.swift
+++ b/Targets/Domain/Sources/Interfaces/SettingServiceType.swift
@@ -13,6 +13,6 @@ import RxSwift
 public protocol SettingServiceType {
 
   // MARK: Methods
-  func withdrawal() -> Single<Void>
   func signOut() -> Single<Void>
+  func logout() -> Single<Void>
 }

--- a/Targets/Domain/Sources/UseCases/MyPageUseCase.swift
+++ b/Targets/Domain/Sources/UseCases/MyPageUseCase.swift
@@ -11,8 +11,8 @@ import RxSwift
 import Kingfisher
 
 public protocol MyPageUseCaseType: FetchVideoPostUseCaseType, FetchProfileUseCaseType {
-  func withdrawl() -> Observable<Void>
   func signOut() -> Observable<Void>
+  func logout() -> Observable<Void>
   func clearCache() -> Observable<Void>
   func deleteVideoPost(postID: Int) -> Observable<Void>
 }
@@ -41,12 +41,12 @@ final class MyPageUseCase: MyPageUseCaseType {
       .asObservable()
   }
 
-  func withdrawl() -> Observable<Void> {
-    settingService.withdrawal().asObservable()
-  }
-
   func signOut() -> Observable<Void> {
     settingService.signOut().asObservable()
+  }
+
+  func logout() -> Observable<Void> {
+    settingService.logout().asObservable()
   }
 
   func clearCache() -> Observable<Void> {

--- a/Targets/Feature/Sources/Common/AppCoordinator.swift
+++ b/Targets/Feature/Sources/Common/AppCoordinator.swift
@@ -145,7 +145,14 @@ private extension AppCoordinator {
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(exitToSignIn),
-      name: NSNotification.Name("reSignIn"),
+      name: .reSignIn,
+      object: nil
+    )
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(transitionToSignIn),
+      name: .logout,
       object: nil
     )
   }
@@ -160,5 +167,9 @@ private extension AppCoordinator {
       .disposed(by: disposeBag)
 
     UIApplication.keyWindow?.rootViewController?.present(alertViewController, animated: true)
+  }
+
+  @objc func transitionToSignIn() {
+    start(from: .signIn)
   }
 }

--- a/Targets/Feature/Sources/Common/Classes/BaseViewController.swift
+++ b/Targets/Feature/Sources/Common/Classes/BaseViewController.swift
@@ -12,7 +12,7 @@ import UIKit
 import ReactorKit
 import RxSwift
 
-class BaseViewController<T: Reactor>: UIViewController, View {
+class BaseViewController<T: Reactor>: UIViewController, View, Alertable {
   typealias Reactor = T
 
   // MARK: Properties

--- a/Targets/Feature/Sources/MyPage/Reactor/MyPageReactor.swift
+++ b/Targets/Feature/Sources/MyPage/Reactor/MyPageReactor.swift
@@ -43,8 +43,8 @@ final class MyPageReactor: Reactor {
     case updatePostsListFilter(postFilter: PostsFilterOption)
     case editProfileButtonTap
     case videoPostCellTap(videoPost: VideoPost)
-    case tapWithdrawalButton
     case tapSignOutButton
+    case tapLogoutButton
     case tapClearCacheButton
     case tapPostDeletionButton(indexNumber: Int)
   }
@@ -120,11 +120,11 @@ final class MyPageReactor: Reactor {
       )
       return .empty()
 
-    case .tapWithdrawalButton:
-      return dependency.useCase.withdrawl().map { .reSignIn }
-
     case .tapSignOutButton:
       return dependency.useCase.signOut().map { .reSignIn }
+
+    case .tapLogoutButton:
+      return dependency.useCase.logout().map { .reSignIn }
 
     case .tapClearCacheButton:
       return dependency.useCase.clearCache()
@@ -177,7 +177,7 @@ final class MyPageReactor: Reactor {
 
     case .reSignIn:
       TokenManager.deleteAll()
-      NotificationCenter.default.post(name: Notification.Name("reSignIn"), object: nil)
+      NotificationCenter.default.post(name: .logout, object: nil)
 
     case .deletePost(let indexNumber):
       newState.uploadedPosts.remove(at: indexNumber)

--- a/Targets/Feature/Sources/MyPage/View/MyPageViewController.swift
+++ b/Targets/Feature/Sources/MyPage/View/MyPageViewController.swift
@@ -27,16 +27,6 @@ final class MyPageViewController: BaseViewController<MyPageReactor> {
   private lazy var deleteVideoPostButton: UIButton = .init()
   private lazy var selectedOptionButtonIndexNumber: Int = .init()
 
-  private lazy var withdrawlAlertViewController: PhoChakAlertViewController = .init(
-    alertType: .withdrawl
-  )
-  private lazy var signOutAlertViewController: PhoChakAlertViewController = .init(
-    alertType: .signOut
-  )
-  private lazy var clearCacheAlertViewController: PhoChakAlertViewController = .init(
-    alertType: .clearCache
-  )
-
   // MARK: Initializer
   init(reactor: MyPageReactor) {
     super.init()
@@ -82,8 +72,8 @@ final class MyPageViewController: BaseViewController<MyPageReactor> {
     }
 
     settingButtons.do {
-      $0.withdrawlButtonDelegate = self
       $0.signOutButtonDelegate = self
+      $0.logoutButtonDelegate = self
       $0.clearCacheButtonDelegate = self
     }
 
@@ -287,17 +277,23 @@ extension MyPageViewController: PostsSectionHeaderDelegate {
 
 // MARK: - SettingButtonsDelegate
 extension MyPageViewController
-: WithdrawalButtonDelegate, SignOutButtonDelegate, ClearCacheButtonDelegate {
-  func tapWithdrawalButton() {
-    present(withdrawlAlertViewController, animated: true)
+: SignOutButtonDelegate, LogoutButtonDelegate, ClearCacheButtonDelegate {
+  func tapSignOutButton() {
+    presentAlert(type: .signOut, okAction: { [weak self] in
+      self?.reactor?.action.onNext(.tapSignOutButton)
+    })
   }
 
-  func tapSignOutButton() {
-    present(signOutAlertViewController, animated: true)
+  func tapLogoutButton() {
+    presentAlert(type: .logout, okAction: { [weak self] in
+      self?.reactor?.action.onNext(.tapLogoutButton)
+    })
   }
 
   func tapClearCacheButton() {
-    present(clearCacheAlertViewController, animated: true)
+    presentAlert(type: .clearCache, okAction: { [weak self] in
+      self?.reactor?.action.onNext(.tapClearCacheButton)
+    })
   }
 }
 
@@ -309,24 +305,6 @@ private extension MyPageViewController {
     rx.viewWillAppear
       .map { MyPageReactor.Action.viewWillAppear }
       .bind(to: reactor.action)
-      .disposed(by: disposeBag)
-
-    withdrawlAlertViewController.acceptButtonAction
-      .map { _ in Action.tapWithdrawalButton }
-      .emit(to: reactor.action)
-      .disposed(by: disposeBag)
-
-    signOutAlertViewController.acceptButtonAction
-      .map { _ in Action.tapSignOutButton }
-      .emit(to: reactor.action)
-      .disposed(by: disposeBag)
-
-    clearCacheAlertViewController.acceptButtonAction
-      .map { _ in Action.tapClearCacheButton }
-      .emit(with: self, onNext: { owner, action in
-        reactor.action.onNext(action)
-        owner.clearCacheAlertViewController.dismiss(animated: true)
-      })
       .disposed(by: disposeBag)
 
     deleteVideoPostButton.rx.tap

--- a/Targets/Service/Sources/Extension/Reactive+.swift
+++ b/Targets/Service/Sources/Extension/Reactive+.swift
@@ -52,7 +52,7 @@ public extension Reactive where Base: MoyaProviderType {
             do {
               if !isValidationToken(try response.map(TokenErrorResponse.self)) {
                 TokenManager.deleteAll()
-                NotificationCenter.default.post(name: Notification.Name("reSignIn"), object: nil)
+                NotificationCenter.default.post(name: .reSignIn, object: nil)
                 return false
               }
             } catch {

--- a/Targets/Service/Sources/Services/SettingService.swift
+++ b/Targets/Service/Sources/Services/SettingService.swift
@@ -23,12 +23,12 @@ final class SettingService: SettingServiceType {
   }
 
   // MARK: Methods
-  func withdrawal() -> Single<Void> {
+  func signOut() -> Single<Void> {
     provider.rx.request(.withdrawl)
       .map { _ in }
   }
 
-  func signOut() -> Single<Void> {
+  func logout() -> Single<Void> {
     provider.rx.request(.signOut)
       .map { _ in }
   }


### PR DESCRIPTION
❗️ 이슈 번호
Closes #46 - Alert 사용성 개선

### 📝 작업 유형

- [x] 리팩토링

### 📙 작업 내역

- Alertable 프로토콜 정의
- 기본 구현을 통해 presentAlert 메서드 제공
- BaseViewController 클래스에 해당 프로토콜을 채택
- 네이밍 수정 및 노티피케이션 네임 하드코드 형태 제거
- Alertable 프로토콜 기반으로 Alert 사용 패턴 수정
- MyPageVC 내 사용되고 있는 AlertVC 변수 제거

<br>