### PR TITLE
QA 버그 수정

### DIFF
--- a/Targets/Feature/Sources/Common/TabBar/PhoChakTabBarController.swift
+++ b/Targets/Feature/Sources/Common/TabBar/PhoChakTabBarController.swift
@@ -9,6 +9,12 @@
 import DesignKit
 import UIKit
 
+enum PhoChakTab: Int {
+  case home
+  case upload
+  case myPage
+}
+
 final class PhoChakTabBarController: UITabBarController, Alertable {
 
   // MARK: Properties
@@ -43,7 +49,7 @@ extension PhoChakTabBarController: UITabBarControllerDelegate {
   ) -> Bool {
     let nextTabIndex = tabBarController.viewControllers?.firstIndex(of: viewController)
 
-    guard nextTabIndex == 1 else { return true }
+    guard nextTabIndex == PhoChakTab.upload.rawValue else { return true }
 
     coordinator?.transition(to: .uploadVideoPost, style: .modal, animated: true, completion: nil)
     return false

--- a/Targets/Feature/Sources/MyPage/Reactor/MyPageReactor.swift
+++ b/Targets/Feature/Sources/MyPage/Reactor/MyPageReactor.swift
@@ -41,7 +41,7 @@ final class MyPageReactor: Reactor {
     case fetchItems(size: Int)
     case updatePostsListFilter(postFilter: PostsFilterOption)
     case editProfileButtonTap
-    case videoPostCellTap(videoPost: VideoPost)
+    case videoPostCellTap(postID: Int)
     case tapSignOutButton
     case tapLogoutButton
     case tapClearCacheButton
@@ -102,12 +102,15 @@ final class MyPageReactor: Reactor {
       )
       return .empty()
 
-    case .videoPostCellTap(let videoPost):
-      var videoPosts: [VideoPost] = currentState.uploadedPosts
+    case .videoPostCellTap(let postID):
+      var videoPosts: [VideoPost]
       if currentState.postFilter == .liked {
-        videoPosts = currentState.likedPosts
+        videoPosts = currentState.likedPosts.filter { !($0.isBlind) }
+      } else {
+        videoPosts = currentState.uploadedPosts.filter { !($0.isBlind) }
       }
-      guard let currentIndex = videoPosts.firstIndex(of: videoPost) else {
+
+      guard let currentIndex = videoPosts.firstIndex(where:  { $0.id == postID }) else {
         return .empty()
       }
 

--- a/Targets/Feature/Sources/MyPage/View/MyPageViewController.swift
+++ b/Targets/Feature/Sources/MyPage/View/MyPageViewController.swift
@@ -116,7 +116,7 @@ extension MyPageViewController: UICollectionViewDelegateFlowLayout {
 
     case .posts:
       return .init(
-        width: (collectionView.frame.width - 54) / 3,
+        width: (collectionView.frame.width - 60) / 3,
         height: view.frame.height * 0.23
       )
     }

--- a/Targets/Feature/Sources/MyPage/View/MyPageViewController.swift
+++ b/Targets/Feature/Sources/MyPage/View/MyPageViewController.swift
@@ -245,10 +245,10 @@ extension MyPageViewController: UICollectionViewDataSource {
 // MARK: - MyPagePostCellDelegate
 extension MyPageViewController: MyPagePostCellDelegate {
   func tapPost(videoPost: VideoPost) {
-    if !videoPost.isBlind {
-      reactor?.action.onNext(.videoPostCellTap(videoPost: videoPost))
-    } else {
+    if videoPost.isBlind {
       presentBlindAlertView()
+    } else {
+      reactor?.action.onNext(.videoPostCellTap(postID: videoPost.id))
     }
   }
 

--- a/Targets/Feature/Sources/PostRolling/View/PostRollingViewController.swift
+++ b/Targets/Feature/Sources/PostRolling/View/PostRollingViewController.swift
@@ -129,6 +129,9 @@ private extension PostRollingViewController {
 
     collectionView.rx.willEndDragging
       .withUnretained(self)
+      .filter { owner, _ in
+        return owner.tabBarController?.selectedIndex != PhoChakTab.myPage.rawValue
+      }
       .map({ (owner, event) -> Int in
         let index = Int(event.targetContentOffset.pointee.x / owner.collectionView.frame.width)
         return index


### PR DESCRIPTION
❗️ 이슈 번호
Closes #61 

### 📝 작업 유형

- [x] 버그 수정

### 📙 작업 내역

- PhoCHakTab 열거형 정의
- 마이페이지에서 상세페이지 접근 이후 페이징시 현재 TabBarController의 selectedTab이 마이페이지가 아닌 경우에만 페이징을 수행하도록 변경
- 마이페이지에서 상세피이지 진입중 데이터소스에 신고누적된 게시글이 포함될 경우 해당 게시글은 제거 적용
- 13 pro max 모델에서 마이페이지 내 아이템이 한 행에 2개만 보이는 현상 수정

<br>
<br>