### PR TITLE
feat: 기존에 노래를 듣고 있었을 경우 상세페이지 진입 이전까지는 기존 노래를 재생하도록 제공

### DIFF
--- a/Targets/Feature/Sources/Common/Extensions/AVPlayer+.swift
+++ b/Targets/Feature/Sources/Common/Extensions/AVPlayer+.swift
@@ -20,4 +20,19 @@ extension AVPlayer {
       self?.play()
     })
   }
+
+  func startWithAmbient() {
+    let audioSession = AVAudioSession.sharedInstance()
+
+    if audioSession.category != .ambient {
+      DispatchQueue.main.async {
+        try? audioSession.setCategory(.ambient, options: [.allowBluetooth])
+        try? audioSession.setActive(true)
+      }
+    }
+
+    seek(to: .zero, completionHandler: { [weak self] _ in
+      self?.play()
+    })
+  }
 }

--- a/Targets/Feature/Sources/Common/Protocols/VideoControllable.swift
+++ b/Targets/Feature/Sources/Common/Protocols/VideoControllable.swift
@@ -24,6 +24,10 @@ extension VideoControllable {
     videoPlayerView.player?.startAtBeginning()
   }
 
+  func playAmbientVideo() {
+    videoPlayerView.player?.startWithAmbient()
+  }
+
   func stopVideo() {
     videoPlayerView.player?.stopAtBeginning()
   }

--- a/Targets/Feature/Sources/Home/View/HomeViewController.swift
+++ b/Targets/Feature/Sources/Home/View/HomeViewController.swift
@@ -153,7 +153,7 @@ private extension HomeViewController {
 
         if index == self?.currentIndex {
           cell.applyLagreScaleTransform {
-            cell.playVideo()
+            cell.playAmbientVideo()
           }
         }
       }

--- a/Targets/Feature/Sources/PostRolling/View/PostRollingViewController.swift
+++ b/Targets/Feature/Sources/PostRolling/View/PostRollingViewController.swift
@@ -52,9 +52,12 @@ final class PostRollingViewController: BaseViewController<PostRollingReactor> {
     navigationItem.hidesBackButton = true
 
     let audioSession = AVAudioSession.sharedInstance()
+    
     if audioSession.category != .playback {
-      try? audioSession.setCategory(.playback, options: [.allowBluetooth])
-      try? audioSession.setActive(true)
+      DispatchQueue.main.async {
+        try? audioSession.setCategory(.playback, options: [.allowBluetooth])
+        try? audioSession.setActive(true)
+      }
     }
   }
 
@@ -75,6 +78,10 @@ final class PostRollingViewController: BaseViewController<PostRollingReactor> {
 
   override func viewWillDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
+
+    DispatchQueue.main.async {
+      try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
 
     NotificationCenter.default.post(name: .muteAllPlayers, object: nibName)
     if tabBarController?.selectedIndex == 0 {

--- a/Targets/Feature/Sources/PostRolling/View/PostRollingViewController.swift
+++ b/Targets/Feature/Sources/PostRolling/View/PostRollingViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 PhoChak. All rights reserved.
 //
 
+import AVFAudio
 import DesignKit
 import Domain
 import UIKit
@@ -49,6 +50,12 @@ final class PostRollingViewController: BaseViewController<PostRollingReactor> {
 
     navigationController?.interactivePopGestureRecognizer?.isEnabled = false
     navigationItem.hidesBackButton = true
+
+    let audioSession = AVAudioSession.sharedInstance()
+    if audioSession.category != .playback {
+      try? audioSession.setCategory(.playback, options: [.allowBluetooth])
+      try? audioSession.setActive(true)
+    }
   }
 
   override func viewDidLayoutSubviews() {

--- a/Targets/PhoChak/Sources/Common/App/SceneDelegate.swift
+++ b/Targets/PhoChak/Sources/Common/App/SceneDelegate.swift
@@ -5,6 +5,7 @@
 //  Created by Ian on 2023/01/14.
 //
 
+import AVFAudio
 import Core
 import Domain
 import Feature
@@ -37,6 +38,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     injector.assemble([ServiceAssembly(), DomainAssembly()])
     appCoordinator = AppCoordinator(dependency: .init(injector: injector))
     coordinatorAssembly(coordinator: appCoordinator!)
+
+    let audioSession = AVAudioSession.sharedInstance()
+    try? audioSession.setCategory(.ambient, options: [.allowBluetooth])
+    try? audioSession.setActive(true)
+
     appCoordinator?.start(from: .splash)
   }
 
@@ -54,9 +60,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
   func sceneWillResignActive(_ scene: UIScene) {}
 
-  func sceneWillEnterForeground(_ scene: UIScene) {}
+  func sceneWillEnterForeground(_ scene: UIScene) {
+    let audioSession = AVAudioSession.sharedInstance()
+    if audioSession.category != .ambient {
+      try? audioSession.setCategory(.ambient, options: [.allowBluetooth])
+      try? audioSession.setActive(true)
+    }
+  }
 
-  func sceneDidEnterBackground(_ scene: UIScene) {}
+  func sceneDidEnterBackground(_ scene: UIScene) {
+    try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+  }
 }
 
 // MARK: - Extension


### PR DESCRIPTION
❗️ 이슈 번호

### 📝 작업 유형

- [x] 신규 기능 추가

### 📙 작업 내역

- 오디오 세션 제어
  - 상세페이지 진입 이전까지 오디오세션의 output을 선점하지 않도록 변경

<br>
<br>

### 💡 참고사항 (없다면 지워도 됩니다!)

- 참고 사항 1
